### PR TITLE
According to the AutocompletionRequest interface (https://developers.…

### DIFF
--- a/src/PlaceAutocompleteField.vue
+++ b/src/PlaceAutocompleteField.vue
@@ -41,7 +41,7 @@ const KEYCODE = {
 const API_REQUEST_OPTIONS = [
     'bounds',
     'location',
-    'component-restrictions',
+    'componentRestrictions',
     'offset',
     'radius',
     'types'


### PR DESCRIPTION
…google.com/maps/documentation/javascript/reference/places-autocomplete-service#AutocompletionRequest) component-restrictions should renamed to componentRestrictions.